### PR TITLE
Downgrade SSL cipher level for game servers

### DIFF
--- a/OneLauncher/MainWindow.py
+++ b/OneLauncher/MainWindow.py
@@ -890,7 +890,7 @@ class MainWindow(QtWidgets.QMainWindow):
             if game:
                 self.currentGame = game
 
-        checkForCertificates(self.logger)
+        game_ssl_ctx = checkForCertificates(self.logger)
 
         # Set news feed to say "Loading ..." until it is replaced by the news.
         self.winMain.txtFeed.setHtml(
@@ -1039,6 +1039,7 @@ class MainWindow(QtWidgets.QMainWindow):
             self.ReturnGLSDataCenter,
             self.ReturnWorldQueueConfig,
             self.ReturnNews,
+            game_ssl_ctx,
         )
         self.configThread.start()
 
@@ -1132,6 +1133,7 @@ class MainWindowThread(QtCore.QThread):
         ReturnGLSDataCenter,
         ReturnWorldQueueConfig,
         ReturnNews,
+        sslContext,
     ):
 
         self.settings = settings
@@ -1145,6 +1147,7 @@ class MainWindowThread(QtCore.QThread):
         self.ReturnGLSDataCenter = ReturnGLSDataCenter
         self.ReturnWorldQueueConfig = ReturnWorldQueueConfig
         self.ReturnNews = ReturnNews
+        self.game_ssl_ctx = sslContext
 
         self.logger = logging.getLogger("OneLauncher")
 
@@ -1222,7 +1225,7 @@ class MainWindowThread(QtCore.QThread):
 
     def GetNews(self):
         try:
-            with urllib.request.urlopen(self.worldQueueConfig.newsStyleSheetURL) as xml_feed:
+            with urllib.request.urlopen(self.worldQueueConfig.newsStyleSheetURL, context=self.game_ssl_ctx) as xml_feed:
                 doc = defusedxml.minidom.parseString(xml_feed.read(), forbid_entities=False)
 
             nodes = doc.getElementsByTagName("div")
@@ -1266,7 +1269,7 @@ class MainWindowThread(QtCore.QThread):
 
             result = HTMLTEMPLATE
 
-            with urllib.request.urlopen(urlNewsFeed) as xml_feed:
+            with urllib.request.urlopen(urlNewsFeed, context=self.game_ssl_ctx) as xml_feed:
                 doc = defusedxml.minidom.parseString(xml_feed.read())
 
             items = doc.getElementsByTagName("item")

--- a/OneLauncher/MainWindow.py
+++ b/OneLauncher/MainWindow.py
@@ -890,7 +890,7 @@ class MainWindow(QtWidgets.QMainWindow):
             if game:
                 self.currentGame = game
 
-        game_ssl_ctx = checkForCertificates(self.logger)
+        sslContext = checkForCertificates(self.logger)
 
         # Set news feed to say "Loading ..." until it is replaced by the news.
         self.winMain.txtFeed.setHtml(
@@ -1039,7 +1039,7 @@ class MainWindow(QtWidgets.QMainWindow):
             self.ReturnGLSDataCenter,
             self.ReturnWorldQueueConfig,
             self.ReturnNews,
-            game_ssl_ctx,
+            sslContext,
         )
         self.configThread.start()
 
@@ -1147,7 +1147,7 @@ class MainWindowThread(QtCore.QThread):
         self.ReturnGLSDataCenter = ReturnGLSDataCenter
         self.ReturnWorldQueueConfig = ReturnWorldQueueConfig
         self.ReturnNews = ReturnNews
-        self.game_ssl_ctx = sslContext
+        self.sslContext = sslContext
 
         self.logger = logging.getLogger("OneLauncher")
 
@@ -1225,7 +1225,7 @@ class MainWindowThread(QtCore.QThread):
 
     def GetNews(self):
         try:
-            with urllib.request.urlopen(self.worldQueueConfig.newsStyleSheetURL, context=self.game_ssl_ctx) as xml_feed:
+            with urllib.request.urlopen(self.worldQueueConfig.newsStyleSheetURL, context=self.sslContext) as xml_feed:
                 doc = defusedxml.minidom.parseString(xml_feed.read(), forbid_entities=False)
 
             nodes = doc.getElementsByTagName("div")
@@ -1269,7 +1269,7 @@ class MainWindowThread(QtCore.QThread):
 
             result = HTMLTEMPLATE
 
-            with urllib.request.urlopen(urlNewsFeed, context=self.game_ssl_ctx) as xml_feed:
+            with urllib.request.urlopen(urlNewsFeed, context=self.sslContext) as xml_feed:
                 doc = defusedxml.minidom.parseString(xml_feed.read())
 
             items = doc.getElementsByTagName("item")

--- a/OneLauncher/OneLauncherUtils.py
+++ b/OneLauncher/OneLauncherUtils.py
@@ -61,7 +61,7 @@ def QByteArray2str(s):
     return str(s, encoding="utf8", errors="replace")
 
 
-onelauncher_ssl_ctx = None
+sslContext = None
 
 
 def checkForCertificates(logger):
@@ -72,14 +72,14 @@ def checkForCertificates(logger):
         logger.error("certificate file expected at '%s' but not found!" % certfile)
         certfile = None
 
-    global onelauncher_ssl_ctx
-    onelauncher_ssl_ctx = ssl.SSLContext(ssl.PROTOCOL_TLSv1)
-    onelauncher_ssl_ctx.set_ciphers('DEFAULT@SECLEVEL=1')
+    global sslContext
+    sslContext = ssl.SSLContext(ssl.PROTOCOL_TLSv1)
+    sslContext.set_ciphers('DEFAULT@SECLEVEL=1')
     if certfile:
-        onelauncher_ssl_ctx.verify_mode = ssl.CERT_REQUIRED
-        onelauncher_ssl_ctx.load_verify_locations(certfile)
+        sslContext.verify_mode = ssl.CERT_REQUIRED
+        sslContext.load_verify_locations(certfile)
         logger.info("SSL certificate verification enabled!")
-    return onelauncher_ssl_ctx
+    return sslContext
 
 
 def WebConnection(urlIn):
@@ -91,7 +91,7 @@ def WebConnection(urlIn):
         url = urlIn[8:].split("/")[0]
         post = urlIn[8:].replace(url, "")
         return (
-            HTTPSConnection(url, context=onelauncher_ssl_ctx),  # nosec
+            HTTPSConnection(url, context=sslContext),  # nosec
             post,
         )
 

--- a/OneLauncher/OneLauncherUtils.py
+++ b/OneLauncher/OneLauncherUtils.py
@@ -74,10 +74,12 @@ def checkForCertificates(logger):
 
     global onelauncher_ssl_ctx
     onelauncher_ssl_ctx = ssl.SSLContext(ssl.PROTOCOL_TLSv1)
+    onelauncher_ssl_ctx.set_ciphers('DEFAULT@SECLEVEL=1')
     if certfile:
         onelauncher_ssl_ctx.verify_mode = ssl.CERT_REQUIRED
         onelauncher_ssl_ctx.load_verify_locations(certfile)
         logger.info("SSL certificate verification enabled!")
+    return onelauncher_ssl_ctx
 
 
 def WebConnection(urlIn):


### PR DESCRIPTION
I recently started seeing SSL errors when trying to launch a game. This is what I got in the terminal output:
```
MainWindow - WARNING - <urlopen error [SSL: DH_KEY_TOO_SMALL] dh key too small (_ssl.c:1145)>
MainWindow - ERROR - [E12] Error getting news
MainWindow - ERROR - [E15] SSL Error occurred in HTTPS connection
```
Using openssl 1.1.1k and python3.9, not sure which one introduced the issue. According to https://askubuntu.com/a/1263098, the default security level was increased to 2; this patch sets it back down to 1 for the news and game queue connections.

Ideally, Standing Stone should update their servers, but I'm not holding my breath.